### PR TITLE
feat: desabilita botão votante quando não há host ativo (#59)

### DIFF
--- a/App/controlador/controller.py
+++ b/App/controlador/controller.py
@@ -315,22 +315,18 @@ class Controlador:
         # Envia uma mensagem de encerramento para todos os votantes e volta para a tela inicial.
         self.mensagem = "sessao encerrada"
         servidor.mandar_mensagem(self.banco_de_dados, self.udp_socket, self.mensagem)
+        self._cleanup()
         self.page.go("/")
 
-    def cleanup(self):
-        """
-        Este método é chamado ao fechar a janela para garantir que
-        todos os recursos de rede e threads sejam liberados.
-        """
-        print("--- APP ENCERRANDO: REALIZANDO LIMPEZA ---")
+    def _cleanup(self):
 
-        # Sinaliza para qualquer thread em execução parar
+        print("--- APP ENCERRANDO: REALIZANDO LIMPEZA ---")
         if hasattr(self, "flag_de_controle") and self.flag_de_controle:
             self.flag_de_controle.set()
 
         # Fecha o socket de rede se ele existir
         if hasattr(self, "udp_socket") and self.udp_socket:
             self.udp_socket.close()
-            print("--- Socket fechado com sucesso. ---")
+            print("--- Porta liberada com sucesso ---")
 
         print("--- LIMPEZA CONCLUÍDA ---")

--- a/App/servidor/cliente.py
+++ b/App/servidor/cliente.py
@@ -4,6 +4,38 @@ import json
 server_addr = ("127.0.0.1", 5555)
 
 
+def verificar_host_ativo() -> bool:
+    """
+    Verifica se existe um host ativo na rede tentando conectar na porta 5555.
+    Retorna True se houver um host ativo, False caso contrário.
+    """
+    try:
+        # Cria um socket temporário para testar a conexão
+        test_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        test_socket.settimeout(1.0)  # Timeout de 1s para esperar resposta
+
+        # Tenta enviar uma mensagem de teste
+        test_message = "host_check"
+        test_socket.sendto(test_message.encode(), server_addr)
+
+        # Tenta receber uma resposta do servidor
+        try:
+            response, addr = test_socket.recvfrom(1024)
+            test_socket.close()
+            return True  # Se recebeu resposta, há um host ativo
+        except socket.timeout:
+            # Se não recebeu resposta, não há host ativo
+            test_socket.close()
+            return False
+
+    except (ConnectionRefusedError, OSError):
+        # Se der qualquer erro, significa que não há host ativo
+        return False
+    except Exception:
+        # Para qualquer outro erro, assume que não há host
+        return False
+
+
 def virar_votante() -> socket.socket:
     votante = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     message = "joined"

--- a/App/servidor/servidor.py
+++ b/App/servidor/servidor.py
@@ -51,13 +51,25 @@ def receber_votantes(
     while not Parar.is_set():
         try:
             dado, votante = server.recvfrom(1000)
+            mensagem = dado.decode()
             ip = votante[0]
             porta = votante[1]
-            # A porta do votante é usada como ID e o IP é armazenado.
-            banco_de_dados.adicionar_votante(porta, ip)
-            # o ip e a porta estão invertidos para testes
-            print(f"votante adicionado ip = {ip}, porta = {porta}")
-            banco_de_dados.serializar_dados()
+
+            # Verifica se é uma mensagem de verificação de host
+            if mensagem == "host_check":
+                # Responde para confirmar que o host está ativo
+                server.sendto("host_active".encode(), votante)
+
+                continue
+            elif mensagem == "joined":
+                # A porta do votante é usada como ID e o IP é armazenado.
+                banco_de_dados.adicionar_votante(porta, ip)
+                # o ip e a porta estão invertidos para testes
+                print(f"votante adicionado ip = {ip}, porta = {porta}")
+                banco_de_dados.serializar_dados()
+            else:
+                print(f"Mensagem desconhecida recebida: {mensagem}")
+
         except socket.timeout:
             continue
     print("votantes definidos")

--- a/App/views/home.py
+++ b/App/views/home.py
@@ -3,6 +3,46 @@ from controlador.controller import Controlador
 
 
 def pagina_inicial(page: ft.Page, controlador: Controlador) -> ft.View:
+    # Verifica o status do host ao carregar a página
+    controlador.verificar_status_host()
+
+    # Botão de votante
+    botao_votante = ft.ElevatedButton(
+        text="virar votante",
+        width=117,
+        height=56,
+        color=ft.Colors.WHITE,
+        bgcolor="#39746F",
+        on_click=controlador.entrar_na_votacao_como_votante,
+        disabled=not controlador.host_ativo,  # Desabilitado se não houver host ativo
+        style=ft.ButtonStyle(
+            padding=20,
+            text_style=ft.TextStyle(
+                size=13,
+                weight=ft.FontWeight.NORMAL,
+                font_family="Inter",
+            ),
+        ),
+    )
+
+    # Botão de host
+    botao_host = ft.ElevatedButton(
+        text="virar host",
+        width=117,
+        height=56,
+        color=ft.Colors.WHITE,
+        bgcolor="#39746F",
+        on_click=controlador.entrar_na_votacao_como_host,
+        style=ft.ButtonStyle(
+            padding=20,
+            text_style=ft.TextStyle(
+                size=13,
+                weight=ft.FontWeight.NORMAL,
+                font_family="Inter",
+            ),
+        ),
+    )
+
     conteudo_da_pagina = [
         # Retângulo superior (topo)
         ft.Container(height=45, bgcolor="#39746F"),
@@ -13,40 +53,8 @@ def pagina_inicial(page: ft.Page, controlador: Controlador) -> ft.View:
             content=ft.Column(
                 controls=[
                     ft.Image(src="logo.png", width=200, height=200),
-                    # Botão de votante
-                    ft.ElevatedButton(
-                        text="virar votante",
-                        width=117,
-                        height=56,
-                        color=ft.Colors.WHITE,
-                        bgcolor="#39746F",
-                        on_click=controlador.entrar_na_votacao_como_votante,
-                        style=ft.ButtonStyle(
-                            padding=20,
-                            text_style=ft.TextStyle(
-                                size=13,
-                                weight=ft.FontWeight.NORMAL,
-                                font_family="Inter",
-                            ),
-                        ),
-                    ),
-                    # Botão de host
-                    ft.ElevatedButton(
-                        text="virar host",
-                        width=117,
-                        height=56,
-                        color=ft.Colors.WHITE,
-                        bgcolor="#39746F",
-                        on_click=controlador.entrar_na_votacao_como_host,
-                        style=ft.ButtonStyle(
-                            padding=20,
-                            text_style=ft.TextStyle(
-                                size=13,
-                                weight=ft.FontWeight.NORMAL,
-                                font_family="Inter",
-                            ),
-                        ),
-                    ),
+                    botao_votante,
+                    botao_host,
                 ],
                 alignment=ft.MainAxisAlignment.CENTER,
                 horizontal_alignment=ft.CrossAxisAlignment.CENTER,
@@ -56,6 +64,8 @@ def pagina_inicial(page: ft.Page, controlador: Controlador) -> ft.View:
         # Retângulo inferior (rodapé)
         ft.Container(height=45, bgcolor="#39746F"),
     ]
+
+    controlador.iniciar_verificacao_periodica_host(botao_votante, page)
 
     return ft.View(
         route="/",


### PR DESCRIPTION
## 📝 Descrição
<ul>
<li>Desabilita o botão de votante quando não há host ativo na rede, melhorando a experiência do usuário e evitando tentativas de entrada sem um host disponível.
<li>Garante que o socket UDP seja corretamente fechado ao encerrar a sala de votação, evitando problemas de porta ocupada em execuções futuras. Essa alteração previne erros de "address already in use" e melhora a robustez do servidor.
</ul>

## 🔗 Issue Relacionada
Closes #59 

## ✅ Checklist
- [x] A issue foi devidamente relacionada usando `Closes #`
- [ ] Foram adicionados testes para as novas funcionalidades
- [ ] A documentação foi atualizada (se necessário)
- [x] O código segue o padrão de estilo do projeto
- [ ] O PR foi revisado por pelo menos um membro do time

## 🚀 Tipo de Mudança
- [ ] Bug fix (correção de bug)
- [x] Nova feature (adição de funcionalidade)
- [ ] Refatoração (melhoria de código sem alterar funcionalidade)
- [ ] Documentação


## 🤝 Revisores
@
