### PR TITLE
feat: Tela intermediaria para host ver o resultado primeiro e assim m…

### DIFF
--- a/App/Eletta.py
+++ b/App/Eletta.py
@@ -8,11 +8,16 @@ def main(page: ft.Page) -> None:
     controlador = controller.Controlador(page)
 
     def mudar_de_pagina(e: ft.ControlEvent) -> None:
+        """
+        Gerencia a navegação entre as diferentes telas (Views) da aplicação,
+        limpando as visualizações anteriores e adicionando a nova de acordo
+        com a rota atual.
+        """
 
-        # --- Correção ---
-        # Isso garante que a thread que escuta o resultado da votação não seja
-        # encerrada prematuramente quando o usuário vota com sucesso ou quando
-        # o tempo se esgota, o que era a causa do congelamento da tela.
+    
+        # Garante que a thread de contagem regressiva do votante seja
+        # interrompida ao navegar para telas onde ela não é necessária.
+        # Isso evita que a aplicação congele ou se comporte de forma inesperada.
         if page.route not in [
             "/votacao",
             "/confirmacao",
@@ -21,8 +26,7 @@ def main(page: ft.Page) -> None:
         ]:
             if hasattr(controlador, "parar_contagem_regressiva_votante"):
                 controlador.parar_contagem_regressiva_votante()
-        # --- Fim da Correção ---
-
+    
         page.views.clear()
         if page.route == "/":
             page.views.append(home.pagina_inicial(page, controlador))
@@ -65,9 +69,12 @@ def main(page: ft.Page) -> None:
         elif page.route == "/resultado":
             page.views.append(home.pagina_do_resultado(page, controlador.mensagem))
 
-        elif page.route == "/resultado_host":
-            page.views.append(host.pagina_do_resultado_host(page, controlador))
+        elif page.route == "/resultado_host_intermediario":
+            page.views.append(host.pagina_do_resultado_host_intermediario(page, controlador))
 
+        elif page.route == "/resultado_host_final":
+            page.views.append(host.pagina_do_resultado_host_final(page, controlador))
+        
         elif page.route == "/sucesso_criacao_sala":
             page.views.append(host.pagina_sucesso_criacao_sala(page))
 
@@ -81,4 +88,5 @@ def main(page: ft.Page) -> None:
 
 
 if __name__ == "__main__":
-    ft.app(target=main, assets_dir="assets")  # Lê o diretório
+    # Inicia a aplicação Flet, especificando o diretório de assets (imagens, etc.)
+    ft.app(target=main, assets_dir="assets")

--- a/App/Eletta.py
+++ b/App/Eletta.py
@@ -14,7 +14,6 @@ def main(page: ft.Page) -> None:
         com a rota atual.
         """
 
-    
         # Garante que a thread de contagem regressiva do votante seja
         # interrompida ao navegar para telas onde ela não é necessária.
         # Isso evita que a aplicação congele ou se comporte de forma inesperada.
@@ -26,7 +25,7 @@ def main(page: ft.Page) -> None:
         ]:
             if hasattr(controlador, "parar_contagem_regressiva_votante"):
                 controlador.parar_contagem_regressiva_votante()
-    
+
         page.views.clear()
         if page.route == "/":
             page.views.append(home.pagina_inicial(page, controlador))
@@ -70,11 +69,13 @@ def main(page: ft.Page) -> None:
             page.views.append(home.pagina_do_resultado(page, controlador.mensagem))
 
         elif page.route == "/resultado_host_intermediario":
-            page.views.append(host.pagina_do_resultado_host_intermediario(page, controlador))
+            page.views.append(
+                host.pagina_do_resultado_host_intermediario(page, controlador)
+            )
 
         elif page.route == "/resultado_host_final":
             page.views.append(host.pagina_do_resultado_host_final(page, controlador))
-        
+
         elif page.route == "/sucesso_criacao_sala":
             page.views.append(host.pagina_sucesso_criacao_sala(page))
 

--- a/App/controlador/controller.py
+++ b/App/controlador/controller.py
@@ -14,6 +14,7 @@ class Controlador:
         self.udp_socket: socket
         self.banco_de_dados: Banco_de_Dados
         self.mensagem: str
+        self.resultado_votacao: str 
         self.process: Thread
         self.flag_de_controle: Event
         self.voto_pendente: str
@@ -285,20 +286,44 @@ class Controlador:
         Timer(2, navegar_para_espera).start()
 
     def encerrar_espera_de_votos(self, e: ft.ControlEvent) -> None:
-        # Encerra a votação, calcula os resultados e navega para a tela de resultados do host.
-
-        # --- Cancela o timer ao encerrar manualmente para evitar execuções futuras ---
+        #Encerra a votação, calcula os resultados e navega para a tela de resultados do host, SEM enviar aos votantes.
         if self.timer_encerramento and self.timer_encerramento.is_alive():
             self.timer_encerramento.cancel()
-        # ------
 
         if not self.flag_de_controle.is_set():
             self.flag_de_controle.set()
             self.process.join()
-            self.mensagem = servidor.mostrar_resultados(
-                self.banco_de_dados, self.udp_socket, self.mensagem
+                # Apenas calcula o resultado e armazena no atributo da classe
+            self.resultado_votacao = servidor.mostrar_resultados(
+                self.banco_de_dados, self.udp_socket, self.mensagem, enviar=False
             )
-            self.page.go("/resultado_host")
+            self.page.go("/resultado_host_intermediario")
+
+
+    def enviar_resultado_para_votantes(self, e: ft.ControlEvent) -> None:
+        """
+        Envia o resultado armazenado para todos os votantes e, em seguida,
+        navega o host para a tela final de resultados.
+        """
+        if self.resultado_votacao:
+            servidor.mandar_mensagem(self.banco_de_dados, self.udp_socket, self.resultado_votacao)
+        
+        # Simula o pop-up de sucesso e depois vai para a tela final
+        dialog = ft.AlertDialog(
+            title=ft.Text("Resultado enviado com sucesso!"),
+            modal=True
+        )
+        self.page.dialog = dialog
+        dialog.open = True
+        self.page.update()
+        
+        # Após um tempo, fecha o diálogo e vai para a tela final de resultado do host
+        time.sleep(2)
+        dialog.open = False
+        self.page.go("/resultado_host_final")
+        self.page.update()
+
+
 
     def criar_nova_pauta(self, e):
         """Chamado quando o host clica em 'Criar Nova Pauta'."""

--- a/App/controlador/controller.py
+++ b/App/controlador/controller.py
@@ -14,7 +14,7 @@ class Controlador:
         self.udp_socket: socket
         self.banco_de_dados: Banco_de_Dados
         self.mensagem: str
-        self.resultado_votacao: str 
+        self.resultado_votacao: str
         self.process: Thread
         self.flag_de_controle: Event
         self.voto_pendente: str
@@ -286,19 +286,18 @@ class Controlador:
         Timer(2, navegar_para_espera).start()
 
     def encerrar_espera_de_votos(self, e: ft.ControlEvent) -> None:
-        #Encerra a votação, calcula os resultados e navega para a tela de resultados do host, SEM enviar aos votantes.
+        # Encerra a votação, calcula os resultados e navega para a tela de resultados do host, SEM enviar aos votantes.
         if self.timer_encerramento and self.timer_encerramento.is_alive():
             self.timer_encerramento.cancel()
 
         if not self.flag_de_controle.is_set():
             self.flag_de_controle.set()
             self.process.join()
-                # Apenas calcula o resultado e armazena no atributo da classe
+            # Apenas calcula o resultado e armazena no atributo da classe
             self.resultado_votacao = servidor.mostrar_resultados(
                 self.banco_de_dados, self.udp_socket, self.mensagem, enviar=False
             )
             self.page.go("/resultado_host_intermediario")
-
 
     def enviar_resultado_para_votantes(self, e: ft.ControlEvent) -> None:
         """
@@ -306,24 +305,23 @@ class Controlador:
         navega o host para a tela final de resultados.
         """
         if self.resultado_votacao:
-            servidor.mandar_mensagem(self.banco_de_dados, self.udp_socket, self.resultado_votacao)
-        
+            servidor.mandar_mensagem(
+                self.banco_de_dados, self.udp_socket, self.resultado_votacao
+            )
+
         # Simula o pop-up de sucesso e depois vai para a tela final
         dialog = ft.AlertDialog(
-            title=ft.Text("Resultado enviado com sucesso!"),
-            modal=True
+            title=ft.Text("Resultado enviado com sucesso!"), modal=True
         )
         self.page.dialog = dialog
         dialog.open = True
         self.page.update()
-        
+
         # Após um tempo, fecha o diálogo e vai para a tela final de resultado do host
         time.sleep(2)
         dialog.open = False
         self.page.go("/resultado_host_final")
         self.page.update()
-
-
 
     def criar_nova_pauta(self, e):
         """Chamado quando o host clica em 'Criar Nova Pauta'."""

--- a/App/servidor/servidor.py
+++ b/App/servidor/servidor.py
@@ -120,7 +120,7 @@ def receber_votos(
 
 # computa os resultados e envia-os para todos votantes
 def mostrar_resultados(
-    banco_de_dados: Banco_de_Dados, server: socket.socket, pauta: str
+    banco_de_dados: Banco_de_Dados, server: socket.socket, pauta: str, enviar: bool = True
 ) -> str:
     resultado = "-----------------Resultado da votação!-----------------\n"
     resultado += f"pauta discutida |{pauta}|\n"
@@ -129,24 +129,24 @@ def mostrar_resultados(
     qtd_abstenção = banco_de_dados.dados["pautas"][pauta]["qtd de votos anulados"]
     total = qtd_a_favor + qtd_contra + qtd_abstenção
 
-    # --- Início da Correção ---
-    # Verifica se o total de votos é zero para evitar o erro de divisão por zero.
     if total == 0:
         porcentagem_a_favor = 0.0
         porcentagem_contra = 0.0
         porcentagem_abstenção = 0.0
     else:
-        # Se houver votos, calcula as porcentagens normalmente.
         porcentagem_a_favor = qtd_a_favor / total * 100
         porcentagem_contra = qtd_contra / total * 100
         porcentagem_abstenção = qtd_abstenção / total * 100
-    # --- Fim da Correção ---
 
     resultado += f"votos a favor = {porcentagem_a_favor:.2f}%\nvotos contra = {porcentagem_contra:.2f}%\nvotos nulos = {porcentagem_abstenção:.2f}%\n"
     resultado += (
         "-------------------------------------------------------------------\n\n"
     )
-    mandar_mensagem(banco_de_dados, server, resultado)
+    
+    # Envia a mensagem apenas se 'enviar' for True
+    if enviar:
+        mandar_mensagem(banco_de_dados, server, resultado)
+        
     return resultado
 
 

--- a/App/servidor/servidor.py
+++ b/App/servidor/servidor.py
@@ -120,7 +120,10 @@ def receber_votos(
 
 # computa os resultados e envia-os para todos votantes
 def mostrar_resultados(
-    banco_de_dados: Banco_de_Dados, server: socket.socket, pauta: str, enviar: bool = True
+    banco_de_dados: Banco_de_Dados,
+    server: socket.socket,
+    pauta: str,
+    enviar: bool = True,
 ) -> str:
     resultado = "-----------------Resultado da votação!-----------------\n"
     resultado += f"pauta discutida |{pauta}|\n"
@@ -142,11 +145,11 @@ def mostrar_resultados(
     resultado += (
         "-------------------------------------------------------------------\n\n"
     )
-    
+
     # Envia a mensagem apenas se 'enviar' for True
     if enviar:
         mandar_mensagem(banco_de_dados, server, resultado)
-        
+
     return resultado
 
 

--- a/App/views/host.py
+++ b/App/views/host.py
@@ -218,18 +218,98 @@ def pagina_do_resultado(page: ft.Page, resultado: str) -> ft.View:
     )
 
 
-def pagina_do_resultado_host(page: ft.Page, controlador: Controlador) -> ft.View:
+def pagina_do_resultado_host_intermediario(page: ft.Page, controlador: Controlador) -> ft.View:
+    """
+    Nova tela que mostra o resultado apenas para o host e dá a opção de enviar.
+    """
+    resultado_formatado = "\n".join(controlador.resultado_votacao.split('\n')[1:-2]) # Remove o cabeçalho e rodapé padrão
+    
+    votos = resultado_formatado.strip().split('\n')
+    
+    # Extrai os valores de votos para exibição
+    votos_favor = "0.00%"
+    votos_contra = "0.00%"
+    votos_nulos = "0.00%"
+
+    for voto in votos:
+        if "votos a favor" in voto:
+            votos_favor = voto.split("=")[1].strip()
+        elif "votos contra" in voto:
+            votos_contra = voto.split("=")[1].strip()
+        elif "votos nulos" in voto:
+            votos_nulos = voto.split("=")[1].strip()
+            
     conteudo_da_pagina = [
-        # Retângulo superior
         ft.Container(height=45, bgcolor="#39746F"),
-        # Container central com conteúdo
         ft.Container(
             expand=True,
             alignment=ft.alignment.center,
             content=ft.Column(
                 [
                     ft.Text(
-                        controlador.mensagem,
+                        "Resultado da votação:",
+                        size=16,
+                        weight=ft.FontWeight.BOLD,
+                        color=ft.Colors.BLACK,
+                        
+                    ),
+                    ft.Text(
+                        f"Concorda: {votos_favor}",
+                        size=16,
+                        color=ft.Colors.BLACK,
+                    ),
+                    ft.Text(
+                        f"Discorda: {votos_contra}",
+                        size=16,
+                        color=ft.Colors.BLACK,
+                    ),
+                    ft.Text(
+                        f"Abstenção: {votos_nulos}",
+                        size=16,
+                        color=ft.Colors.BLACK,
+                    ),
+                    ft.Container(height=30), # Espaçador
+                    ft.ElevatedButton(
+                        text="Enviar resultado",
+                        width=200,
+                        height=50,
+                        bgcolor="#39746F",
+                        color=ft.Colors.WHITE,
+                        on_click=controlador.enviar_resultado_para_votantes,
+                    ),
+                ],
+                alignment=ft.MainAxisAlignment.CENTER,
+                horizontal_alignment=ft.CrossAxisAlignment.CENTER,
+                spacing=20,
+            ),
+        ),
+        ft.Container(height=45, bgcolor="#39746F"),
+    ]
+
+    return ft.View(
+        "/resultado_host_intermediario",
+        controls=conteudo_da_pagina,
+        vertical_alignment=ft.MainAxisAlignment.CENTER,
+        horizontal_alignment=ft.CrossAxisAlignment.CENTER,
+        bgcolor=ft.Colors.WHITE,
+        padding=0,
+    )
+
+
+def pagina_do_resultado_host_final(page: ft.Page, controlador: Controlador) -> ft.View:
+    """
+    Tela final do host, que aparece após o resultado ser enviado.
+    É a mesma que a tela de resultado atual.
+    """
+    conteudo_da_pagina = [
+        ft.Container(height=45, bgcolor="#39746F"),
+        ft.Container(
+            expand=True,
+            alignment=ft.alignment.center,
+            content=ft.Column(
+                [
+                    ft.Text(
+                        controlador.resultado_votacao, # Usa o resultado já calculado
                         size=16,
                         weight=ft.FontWeight.NORMAL,
                         color="#000000",
@@ -242,14 +322,6 @@ def pagina_do_resultado_host(page: ft.Page, controlador: Controlador) -> ft.View
                         bgcolor="#39746F",
                         color=ft.Colors.WHITE,
                         on_click=controlador.criar_nova_pauta,
-                        style=ft.ButtonStyle(
-                            padding=20,
-                            text_style=ft.TextStyle(
-                                size=14,
-                                weight=ft.FontWeight.NORMAL,
-                                font_family="Inter",
-                            ),
-                        ),
                     ),
                     ft.ElevatedButton(
                         text="Encerrar Sessão",
@@ -258,14 +330,6 @@ def pagina_do_resultado_host(page: ft.Page, controlador: Controlador) -> ft.View
                         bgcolor="#C83A3A",
                         color=ft.Colors.WHITE,
                         on_click=controlador.encerrar_sessao,
-                        style=ft.ButtonStyle(
-                            padding=20,
-                            text_style=ft.TextStyle(
-                                size=14,
-                                weight=ft.FontWeight.NORMAL,
-                                font_family="Inter",
-                            ),
-                        ),
                     ),
                 ],
                 alignment=ft.MainAxisAlignment.CENTER,
@@ -273,12 +337,11 @@ def pagina_do_resultado_host(page: ft.Page, controlador: Controlador) -> ft.View
                 spacing=30,
             ),
         ),
-        # Retângulo inferior
         ft.Container(height=45, bgcolor="#39746F"),
     ]
 
     return ft.View(
-        "/resultado_host",
+        "/resultado_host_final",
         controls=conteudo_da_pagina,
         vertical_alignment=ft.MainAxisAlignment.CENTER,
         horizontal_alignment=ft.CrossAxisAlignment.CENTER,

--- a/App/views/host.py
+++ b/App/views/host.py
@@ -218,14 +218,18 @@ def pagina_do_resultado(page: ft.Page, resultado: str) -> ft.View:
     )
 
 
-def pagina_do_resultado_host_intermediario(page: ft.Page, controlador: Controlador) -> ft.View:
+def pagina_do_resultado_host_intermediario(
+    page: ft.Page, controlador: Controlador
+) -> ft.View:
     """
     Nova tela que mostra o resultado apenas para o host e dá a opção de enviar.
     """
-    resultado_formatado = "\n".join(controlador.resultado_votacao.split('\n')[1:-2]) # Remove o cabeçalho e rodapé padrão
-    
-    votos = resultado_formatado.strip().split('\n')
-    
+    resultado_formatado = "\n".join(
+        controlador.resultado_votacao.split("\n")[1:-2]
+    )  # Remove o cabeçalho e rodapé padrão
+
+    votos = resultado_formatado.strip().split("\n")
+
     # Extrai os valores de votos para exibição
     votos_favor = "0.00%"
     votos_contra = "0.00%"
@@ -238,7 +242,7 @@ def pagina_do_resultado_host_intermediario(page: ft.Page, controlador: Controlad
             votos_contra = voto.split("=")[1].strip()
         elif "votos nulos" in voto:
             votos_nulos = voto.split("=")[1].strip()
-            
+
     conteudo_da_pagina = [
         ft.Container(height=45, bgcolor="#39746F"),
         ft.Container(
@@ -251,7 +255,6 @@ def pagina_do_resultado_host_intermediario(page: ft.Page, controlador: Controlad
                         size=16,
                         weight=ft.FontWeight.BOLD,
                         color=ft.Colors.BLACK,
-                        
                     ),
                     ft.Text(
                         f"Concorda: {votos_favor}",
@@ -268,7 +271,7 @@ def pagina_do_resultado_host_intermediario(page: ft.Page, controlador: Controlad
                         size=16,
                         color=ft.Colors.BLACK,
                     ),
-                    ft.Container(height=30), # Espaçador
+                    ft.Container(height=30),  # Espaçador
                     ft.ElevatedButton(
                         text="Enviar resultado",
                         width=200,
@@ -309,7 +312,7 @@ def pagina_do_resultado_host_final(page: ft.Page, controlador: Controlador) -> f
             content=ft.Column(
                 [
                     ft.Text(
-                        controlador.resultado_votacao, # Usa o resultado já calculado
+                        controlador.resultado_votacao,  # Usa o resultado já calculado
                         size=16,
                         weight=ft.FontWeight.NORMAL,
                         color="#000000",


### PR DESCRIPTION
…andar para o votante  - refs #93

## 📝 Descrição
Este Pull Request introduz uma nova etapa no fluxo de votação. Após o encerramento da coleta de votos, o resultado é exibido primeiramente apenas para o host em uma tela intermediária. A partir dessa tela, o host tem o controle para decidir quando enviar o resultado final para todos os votantes conectados.

## 🔗 Issue Relacionada
Closes #93

## ✅ Checklist
- [x] A issue foi devidamente relacionada usando `Closes #`
- [ ] Foram adicionados testes para as novas funcionalidades
- [ ] A documentação foi atualizada (se necessário)
- [x] O código segue o padrão de estilo do projeto
- [x] O PR foi revisado por pelo menos um membro do time

## 🚀 Tipo de Mudança
- [ ] Bug fix (correção de bug)
- [ ] Nova feature (adição de funcionalidade)
- [x] Refatoração (melhoria de código sem alterar funcionalidade)
- [ ] Documentação

## 📸 Prints (se aplicável)
![image](https://github.com/user-attachments/assets/07eaf2f4-dff2-4b7c-9d50-84fc516151b6)

## 🤝 Revisores
@daviaraujobr @GiovanniMateus @enzo-fb 
